### PR TITLE
Use lowest matching threshold message

### DIFF
--- a/src/components/PullRequestsGauge.jsx
+++ b/src/components/PullRequestsGauge.jsx
@@ -44,7 +44,7 @@ class PullRequestsGauge extends Component {
         let cappedValue    = Math.min(pullRequests.length, _.max(_.pluck(thresholds, 'threshold')));
         let message        = null;
         let normThresholds = thresholds.map(threshold => {
-            if (cappedValue <= threshold.threshold) {
+            if (message === null && cappedValue <= threshold.threshold) {
                 message = threshold.message;
             }
 


### PR DESCRIPTION
Currently we always get the message for the highest threshold, since it overwrites it everytime
