### PR TITLE
Provide optional PullRequests title

### DIFF
--- a/src/components/PullRequests.jsx
+++ b/src/components/PullRequests.jsx
@@ -33,12 +33,18 @@ class PullRequests extends Component {
 
     render() {
         let { pullRequests } = this.state;
-        let { title } = this.props
+        let { repository, title } = this.props
+
+        let titleNode = title === undefined ? (
+            <span>
+                <span className="widget__header__subject">{repository}</span> Pull Requests
+            </span>
+        ) : title;
 
         return (
             <div>
                 <div className="widget__header">
-                    {title}
+                    {titleNode}
                     <span className="widget__header__count">
                         {pullRequests.length}
                     </span>
@@ -56,11 +62,7 @@ class PullRequests extends Component {
 
 PullRequests.propTypes = {
     repository: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired
-};
-
-PullRequests.defaultProps = {
-    title: 'Pull Requests'
+    title:      PropTypes.string
 };
 
 reactMixin(PullRequests.prototype, ListenerMixin);

--- a/src/components/PullRequests.jsx
+++ b/src/components/PullRequests.jsx
@@ -33,11 +33,12 @@ class PullRequests extends Component {
 
     render() {
         let { pullRequests } = this.state;
+        let { title } = this.props
 
         return (
             <div>
                 <div className="widget__header">
-                    Pull requests
+                    {title}
                     <span className="widget__header__count">
                         {pullRequests.length}
                     </span>
@@ -54,7 +55,12 @@ class PullRequests extends Component {
 }
 
 PullRequests.propTypes = {
-    repository: PropTypes.string.isRequired
+    repository: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired
+};
+
+PullRequests.defaultProps = {
+    title: 'Pull Requests'
 };
 
 reactMixin(PullRequests.prototype, ListenerMixin);

--- a/src/tests/PullRequests.test.js
+++ b/src/tests/PullRequests.test.js
@@ -7,6 +7,8 @@ import mockery      from 'mockery';
 var PullRequests;
 var pullRequests;
 
+const repository = 'plouc/mozaik';
+
 describe('Github — PullRequests', () => {
 
     let sandbox;
@@ -23,7 +25,7 @@ describe('Github — PullRequests', () => {
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
-        pullRequests = TestUtils.renderIntoDocument(<PullRequests repository="plouc/mozaik" />);
+        pullRequests = TestUtils.renderIntoDocument(<PullRequests repository={repository} />);
     });
 
     afterEach(() => {
@@ -38,9 +40,9 @@ describe('Github — PullRequests', () => {
 
     it('should return correct api request', () => {
         expect(pullRequests.getApiRequest()).to.eql({
-            id:     'github.pullRequests.plouc/mozaik',
+            id:     `github.pullRequests.${repository}`,
             params: {
-                repository: 'plouc/mozaik'
+                repository: repository
             }
         });
     });
@@ -81,14 +83,15 @@ describe('Github — PullRequests', () => {
         expect(count.getDOMNode().textContent).to.equal('3');
     });
 
-    it('renders default title "Pull Requests"', () => {
+    it('renders default title `repository Pull Requests`', () => {
         let title = TestUtils.findRenderedDOMComponentWithClass(pullRequests, 'widget__header');
-        expect(title.getDOMNode().textContent).to.contain('Pull Requests');
+        expect(title.getDOMNode().textContent).to.contain(`${repository} Pull Requests`);
     });
 
     it('renders custom title when supplied', () => {
-        pullRequests = TestUtils.renderIntoDocument(<PullRequests repository="plouc/mozaik" title="Custom Title" />)
+        let customTitle = 'Custom Title';
+        pullRequests = TestUtils.renderIntoDocument(<PullRequests repository={repository} title={customTitle} />)
         let title = TestUtils.findRenderedDOMComponentWithClass(pullRequests, 'widget__header');
-        expect(title.getDOMNode().textContent).to.contain('Custom Title');
+        expect(title.getDOMNode().textContent).to.contain(customTitle);
     });
 });

--- a/src/tests/PullRequests.test.js
+++ b/src/tests/PullRequests.test.js
@@ -80,4 +80,15 @@ describe('Github — PullRequests', () => {
         let count = TestUtils.findRenderedDOMComponentWithClass(pullRequests, 'widget__header__count');
         expect(count.getDOMNode().textContent).to.equal('3');
     });
+
+    it('renders default title "Pull Requests"', () => {
+        let title = TestUtils.findRenderedDOMComponentWithClass(pullRequests, 'widget__header');
+        expect(title.getDOMNode().textContent).to.contain('Pull Requests');
+    });
+
+    it('renders custom title when supplied', () => {
+        pullRequests = TestUtils.renderIntoDocument(<PullRequests repository="plouc/mozaik" title="Custom Title" />)
+        let title = TestUtils.findRenderedDOMComponentWithClass(pullRequests, 'widget__header');
+        expect(title.getDOMNode().textContent).to.contain('Custom Title');
+    });
 });


### PR DESCRIPTION
This commit allows the user to supply an optional `title` property for
the PullRequests widget. When `title` is not supplied, the widget falls
back to the previous title, "Pull Requests", so as not to break the
current functionality.

An example configuration of the PullRequests widget with the `title`
property:

``` javascript
{
  type: 'github.pull_requests',
  title: 'Main Repo',
  repository: 'plouc/mozaik',
  columns: 1, rows: 1, x: 0, y: 0
}
```

A screenshot with the `title` supplied:

![screen shot 2016-03-24 at 11 59 42](https://cloud.githubusercontent.com/assets/2344137/14022854/0e87bd48-f1b8-11e5-886a-f541b58ad4a3.png)

A screenshot without the `title` supplied:

![screen shot 2016-03-24 at 12 03 43](https://cloud.githubusercontent.com/assets/2344137/14022950/7a39485e-f1b8-11e5-8a55-15bde6113c40.png)

My use case: I am setting up a dashboard for a client project that contains multiple repos, and we will want to keep track of each repo's pull requests and supply named titles to easily differentiate between each repo. 

Let me know what you think of this approach.
